### PR TITLE
Play Presets from rundown JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const instance_skel = require('../../instance_skel')
-const { initPresets } = require('./presets')
+const { initPresets, getRundown } = require('./presets')
 const fetch = require('node-fetch')
 let debug = () => {}
 
@@ -14,8 +14,8 @@ class instance extends instance_skel {
 	 */
 	constructor(system, id, config) {
 		super(system, id, config)
-
 		this.actions() // export actions
+		
 	}
 
 	/**
@@ -280,7 +280,7 @@ class instance extends instance_skel {
 				regex: this.REGEX_PORT,
 				default: '5000',
 				required: true,
-			},
+			}
 		]
 	}
 
@@ -319,7 +319,8 @@ class instance extends instance_skel {
 	 * @access protected
 	 * @since 1.1.0
 	 */
-	initPresets() {
+	async initPresets() {
+		this.rundownItems = await getRundown(this.config.host,this.config.port)
 		this.setPresetDefinitions(initPresets.bind(this)())
 	}
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,13 @@
 	"description": "Module to control SPX-GC",
 	"main": "index.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "mocha"
 	},
 	"author": "JeffreyDavidsz <jeffrey.davidsz@vicreo.eu>",
 	"license": "MIT",
-  "repository": "https://github.com/bitfocus/companion-module-spx-gc.git"
+	"repository": "https://github.com/bitfocus/companion-module-spx-gc.git",
+	"dependencies": {
+		"chia": "0.0.1",
+		"mocha": "^9.1.3"
+	}
 }

--- a/test/presets.js
+++ b/test/presets.js
@@ -1,0 +1,84 @@
+var assert = require('assert');
+const { expect } = require('chai');
+const instance = require('..');
+const { initPresets, getRundown, convertRundown } = require('../presets');
+
+
+describe('Test Presets', function () {
+    var presets = []
+    beforeEach(async function () {
+        var instance = {
+            rgb: function (r, b, g) {
+                return `#${r}${b}${b}`
+            },
+            initPresets: initPresets
+        }
+        presets = await instance.initPresets(instance);
+        return presets
+    }
+    )
+    it('Start and so on still in the List', async function () {
+        const items = presets.map((preset) => {
+            return preset.label
+        })
+        expect(items).to.be.an('array')
+        expect(items).to.include.members([
+            'Start',
+            'Stop',
+            'Continue',
+            'Stop All Layers',
+            'First',
+            'Next',
+            'Previous',
+            'Last'
+        ])
+    });
+
+});
+
+describe('Test Rundown Presets', function () {
+    var presets = []
+    beforeEach(async function () {
+        var instance = {
+            rgb: function (r, b, g) {
+                return `#${r}${b}${b}`
+            },
+            initPresets: initPresets,
+            rundownItems: [{ itemID: '1612292117446', title: 'Testname' }]
+        }
+        presets = await instance.initPresets(instance);
+        return presets
+    }
+    )
+    it('Play Testname in the Preset List', async function () {
+        
+        const items = presets.map((preset) => {
+            return preset.label
+        })
+        expect(items).to.be.an('array').that.includes("Play Testname")
+    });
+
+});
+
+describe('Get rundown from SPX-GC API', async function(){
+    it.skip('run against Standard local', async function(){
+        const rundown = await getRundown("localhost",4000)
+    })
+    it('convert the Rundown JSON correct', function(){
+        const rundown = {"warning":"Modifications done in the GC will overwrite this file.","smartpx":"(c) 2020-2021 SmartPX","updated":"2021-12-05T23:06:34.002Z","templates":[{"description":"Ticker","playserver":"OVERLAY","playchannel":"1","playlayer":"3","webplayout":"3","out":"manual","uicolor":"7","DataFields":[{"ftype":"instruction","value":"This is an example from the default template pack. For more templates see ▶ spxgc.com/store"},{"field":"f0","ftype":"textfield","title":"Headline","value":"LATER IN THE SHOW"},{"field":"f1","ftype":"textfield","title":"Content","value":"We will figure out how to update this manual ticker text"}],"onair":"false","dataformat":"xml","imported":"1638745537822","relpath":"smartpx/Template_Pack_1/SPX1_TICKER_MANUAL.html","itemID":"1638745575655"},{"description":"Ticker","playserver":"OVERLAY","playchannel":"1","playlayer":"3","webplayout":"3","out":"manual","uicolor":"7","DataFields":[{"ftype":"instruction","value":"This is an example from the default template pack. For more templates see ▶ spxgc.com/store"},{"field":"f0","ftype":"textfield","title":"Headline","value":"LATER IN THE SHOW 2"},{"field":"f1","ftype":"textfield","title":"Content","value":"We will figure out how to update this manual ticker text"}],"onair":"false","dataformat":"xml","imported":"1638745537822","relpath":"smartpx/Template_Pack_1/SPX1_TICKER_MANUAL.html","itemID":"1638745581074"}]}
+        const items = convertRundown(rundown)
+        expect(items).to.be.an('array').that.has.lengthOf(2)
+        items.map((item)=>{
+            expect(item).to.have.all.keys('itemID', 'title');
+        })
+        expect(items[0].itemID).to.be.equal('1638745575655')
+        expect(items[1].itemID).to.be.equal('1638745581074')
+        expect(items[0].title).to.be.equal('LATER IN THE SHOW')
+        expect(items[1].title).to.be.equal('LATER IN THE SHOW 2')
+    })
+    it('test if convert Rundown can handle empty JSON', function(){
+        const rundown = {}
+        const items = convertRundown(rundown)
+        expect(items).to.be.an('array').to.deep.equal([])
+    })
+});


### PR DESCRIPTION
I added an API to SPX-GC to get the current Rundown JSON.                   
With this code there will be presets that are generated from the Rundown    
This will make it easier to use for users because they don't need to manually read the JSON file to get the Item ID's.

I added some Tests to make sure I don't break existing Presets.

In this Version, it will only get the Rundown on first connect/reconnect.
I hope I can change that to a polling approach later, or even use the socket.io used in SPX-CG internally.